### PR TITLE
fixed path issue in outputFile regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ var pdc     = require('pdc');
 var through = require('through2');
 var gutil   = require('gulp-util');
 var mkdirp  = require('mkdirp');
+var path    = require('path');
 
 // -----------------------------------------------------------------------------
 // PLUGIN
@@ -62,7 +63,7 @@ module.exports = function(opts) {
         outputFile = outputFile.replace(inputFileType, outputFileType);
 
         // create directory for pdf
-        var oDir = outputFile.replace(/[^\/]+$/, '');
+        var oDir = path.dirname(outputFile);
         mkdirp(oDir, function(err) {
             if (err) {
                 this.emit('error', err.toString());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-pandoc-writer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Write files from Pandoc that are not streamable (DOCX, EPUB, etc) but that are also not PDFs.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
removed regex on `outputFile` in replacement of `path.dirname`, which then successfully creates the output directory structure when deeply nested.